### PR TITLE
[VM-523] B: Prevent uncaught typeError when ElasticsuiteCatalog is no…

### DIFF
--- a/Api/CollectionProcessorInterface.php
+++ b/Api/CollectionProcessorInterface.php
@@ -24,18 +24,18 @@ interface CollectionProcessorInterface
     /**
      * Apply store limitation to a product collection.
      *
-     * @param \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection Product Collection
+     * @param \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection|\Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection $collection Product Collection
      *
      * @return void
      */
-    public function applyStoreLimitation(\Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection);
+    public function applyStoreLimitation($collection);
 
     /**
      * Apply store sort orders to a product collection.
      *
-     * @param \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection Product Collection
+     * @param \Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection|\Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection $collection Product Collection
      *
      * @return void
      */
-    public function applyStoreSortOrders(\Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection);
+    public function applyStoreSortOrders($collection);
 }

--- a/Model/CollectionProcessor.php
+++ b/Model/CollectionProcessor.php
@@ -77,7 +77,7 @@ class CollectionProcessor implements CollectionProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function applyStoreLimitation(\Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection)
+    public function applyStoreLimitation($collection)
     {
         if (!$this->settingsHelper->isDriveMode()) {
             return;
@@ -104,7 +104,7 @@ class CollectionProcessor implements CollectionProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function applyStoreSortOrders(\Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection $collection)
+    public function applyStoreSortOrders($collection)
     {
         if (!$this->settingsHelper->isDriveMode()) {
             return;


### PR DESCRIPTION
…t enabled

Following error was thrown:
```
Fatal error: Uncaught TypeError: Argument 1 passed to Smile\RetailerOffer\Model\CollectionProcessor::applyStoreLimitation() must be an instance of Smile\ElasticsuiteCatalog\Model\ResourceModel\Product\Fulltext\Collection, instance of Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection\Interceptor given, called in /data/web/magento2/vendor/smile/module-retailer-offer/Plugin/LayerPlugin.php on line 46 and defined in /data/web/magento2/vendor/smile/module-retailer-offer/Model/CollectionProcessor.php on line 80```