### PR TITLE
Fix category page - add facet offer.price

### DIFF
--- a/Model/Layer/Filter/Price.php
+++ b/Model/Layer/Filter/Price.php
@@ -116,11 +116,13 @@ class Price extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Price
             return parent::addFacetToCollection($config);
         }
 
-        $facetField = $this->getFilterField();
-        $facetType  = BucketInterface::TYPE_HISTOGRAM;
         $retailerId = $this->getRetailerId();
 
-        $facetConfig = ['nestedFilter' => ['offer.seller_id' => $retailerId], 'minDocCount' => 1];
+        $facetConfig = [
+            'name'         => $this->getFilterField(),
+            'type'         => BucketInterface::TYPE_HISTOGRAM,
+            'nestedFilter' => ['offer.seller_id' => $retailerId], 'minDocCount' => 1,
+        ];
 
         $calculation = $this->dataProvider->getRangeCalculationValue();
         if ($calculation === \Magento\Catalog\Model\Layer\Filter\DataProvider\Price::RANGE_CALCULATION_MANUAL) {
@@ -130,7 +132,7 @@ class Price extends \Smile\ElasticsuiteCatalog\Model\Layer\Filter\Price
         }
 
         $productCollection = $this->getLayer()->getProductCollection();
-        $productCollection->addFacet($facetField, $facetType, $facetConfig);
+        $productCollection->addFacet($facetConfig);
 
         return $this;
     }


### PR DESCRIPTION
**Environment**
Magento 2.3.1 (vanilla)
ElasticSuite: 2.7
Mode: Drive

**Description**
While adding facet price, offer.price is a string instead of being an array with a key element "name"

**Manual testing scenarios (*)**
Go to Category page with drive mode activated.

**Error**
File where exception happened: vendor/smile/elasticsuite/src/module-elasticsuite-catalog/Model/ResourceModel/Product/Fulltext/Collection.php

Line 299:
`
public function addFacet($facetConfig)
    {
        $this->facets[$facetConfig['name']] = $facetConfig;
        return $this;
    }
`
Output of $facetConfig:

Array
(
    [type] => queryGroupBucket
    [name] => categories
    [queries] => Array
        (
        )

)
Array
(
    [name] => name
    [type] => termBucket
    [size] => 10
    [sortOrder] => _count
)

String
offer.price

This causes an exception #0 (Exception): Warning: Illegal string offset 'name'