### PR TITLE
Remove local dependency on MutationObserver

### DIFF
--- a/view/adminhtml/web/js/component/offer/product.js
+++ b/view/adminhtml/web/js/component/offer/product.js
@@ -13,8 +13,7 @@
 
 define([
     'Magento_Ui/js/form/components/html',
-    'jquery',
-    'MutationObserver'
+    'jquery'
 ], function (Component, $) {
     'use strict';
 


### PR DESCRIPTION
**Description (*)**

During create offer in browser console errors:
GET adminhtml/Magento/backend/en_US/MutationObserver.js net::ERR_ABORTED 404
and
[] [ERROR] Failed to load the "Smile_RetailerOffer/js/component/offer/product" component.

**Related Pull Requests**

**Fixed Issues (if relevant)**

**Manual testing scenarios (*)**

1. Create new offer
2. Error in browser console

**Questions or comments**